### PR TITLE
Ignoring aviary

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -32,7 +32,7 @@ namespace :test do
       puts 'Checking for link errors in *iiif.io* sites'
       opts = {
         checks_to_ignore: ['ImageCheck', 'HtmlCheck', 'ScriptCheck'],
-        url_ignore: [/^((?!iiif\.io).)*$/, 'github'] # temporarily ignore iiif.io github repo errors
+        url_ignore: [/^((?!iiif\.io).)*$/, 'github','iiif.aviaryplatform.com'] # temporarily ignore iiif.io github repo errors, ignore aviary which returns 403
       }
       HTMLProofer.check_directory(SITE_DIR, opts).run
     end


### PR DESCRIPTION
For some reason aviary returns a 403:

https://iiif.aviaryplatform.com/player?manifest=https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json